### PR TITLE
feat: add blocking pop call

### DIFF
--- a/kpq/keyed_priority_queue.go
+++ b/kpq/keyed_priority_queue.go
@@ -145,7 +145,7 @@ func (pq *KeyedPriorityQueue[K, V]) Pop() (K, V, bool) {
 
 // BlockingPop removes and returns the highest priority key and value from the priority queue.
 // In case queue is empty, it blocks until next Push happens or ctx is closed.
-func (pq *KeyedPriorityQueue[K, V]) BlockingPop(ctx context.Context) (K, V) {
+func (pq *KeyedPriorityQueue[K, V]) BlockingPop(ctx context.Context) (K, V, bool) {
 	pq.mu.Lock()
 
 	if len(pq.pm) == 0 {
@@ -155,14 +155,15 @@ func (pq *KeyedPriorityQueue[K, V]) BlockingPop(ctx context.Context) (K, V) {
 		case <-ctx.Done():
 			var k K
 			var v V
-			return k, v
+			return k, v, false
 		case pair := <-pq.fastTrack:
-			return pair.k, pair.v
+			return pair.k, pair.v, true
 		}
 	}
 
 	defer pq.mu.Unlock()
-	return pq.pop()
+	k, v := pq.pop()
+	return k, v, true
 }
 
 func (pq *KeyedPriorityQueue[K, V]) pop() (K, V) {

--- a/kpq/keyed_priority_queue.go
+++ b/kpq/keyed_priority_queue.go
@@ -60,7 +60,7 @@ func newKeyNotFoundError[K comparable](k K) error {
 // CmpFunc is a generic function type used for ordering the priority queue.
 type CmpFunc[V any] func(x, y V) bool
 
-// TODO comment
+// pair is a pair of key and value that might be put or read from the queue.
 type pair[K comparable, V any] struct {
 	k K
 	v V
@@ -142,9 +142,8 @@ func (pq *KeyedPriorityQueue[K, V]) Pop() (K, V, bool) {
 	return k, v, true
 }
 
-// TODO BlockingPop
-// Pop removes and returns the highest priority key and value from the priority queue.
-// It returns false as its last return value if the priority queue is empty; otherwise, true.
+// BlockingPop removes and returns the highest priority key and value from the priority queue.
+// In case queue is empty, it blocks until next Push happens.
 func (pq *KeyedPriorityQueue[K, V]) BlockingPop() (K, V) {
 	pq.mu.Lock()
 

--- a/kpq/keyed_priority_queue_test.go
+++ b/kpq/keyed_priority_queue_test.go
@@ -1,6 +1,7 @@
 package kpq
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -314,7 +315,7 @@ func TestKeyedPriorityQueue_BlockingPop(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(fmt.Sprintf("%s_%d", tc.wantKey, tc.wantValue), func(t *testing.T) {
-				gotKey, gotValue := pq.BlockingPop()
+				gotKey, gotValue, _ := pq.BlockingPop(context.Background())
 
 				if gotKey != tc.wantKey {
 					t.Errorf("pq.BlockingPop(): got key %q; want %q", gotKey, tc.wantKey)
@@ -394,7 +395,7 @@ func TestKeyedPriorityQueue_BlockingPop(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(fmt.Sprintf("%s_%d", tc.wantKey, tc.wantValue), func(t *testing.T) {
-				gotKey, gotValue := pq.BlockingPop()
+				gotKey, gotValue, _ := pq.BlockingPop(context.Background())
 
 				if gotKey != tc.wantKey {
 					t.Errorf("pq.Pop(): got key %q; want %q", gotKey, tc.wantKey)


### PR DESCRIPTION
This PR adds `BlockingPop()` method for Priority Queue.

The difference with `Pop()` is that in case of empty queue it blocks until next `Push()` call.
It is useful when one has a delay in the stream of objects that are put into the queue and processing next object from queue takes time. Instead of implementing some kind of sleep timer, user can use a blocking call. And while the read object will be processed somehow, next elements that will be put into queue will be sorted as usual.